### PR TITLE
Add README, CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ A member of the development team will review your changes to confirm that they c
 ## Recognizing contributions
 
 BIDS follows the [all-contributors][link_allcontributors] specification, so we welcome and recognize all contributions from documentation to testing to code development.
-You can see a list of current contributors in our [README][link_readme].
+You can see a list of current contributors in our [specification][link_bids_spec].
 
 ## Thank you!
 
@@ -67,7 +67,6 @@ You're awesome. :wave::smiley:
 [link_labels]: https://github.com/INCF/BIDS/labels
 [link_fork]: https://help.github.com/articles/fork-a-repo/
 [link_requests]: https://github.com/INCF/BIDS/labels/requests
-[link_readme]: https://github.com/INCF/BIDS/blob/gh-pages/README.md
 [link_helpwanted]: https://github.com/INCF/BIDS/labels/help%20wanted
 [link_code_of_conduct]: http://www.brainhack.org/code-of-conduct.html
 [link_stemmrolemodels]: https://github.com/KirstieJane/STEMMRoleModels
@@ -79,3 +78,4 @@ You're awesome. :wave::smiley:
 [link_branches]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
 [link_react]: https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments
 [link_signupinstructions]: https://help.github.com/articles/signing-up-for-a-new-github-account
+[link_bids_spec]: https://docs.google.com/document/d/1HFUkAEE-pB-angVcYe6pf_-fVf4sCpOHKesUvfb8Grc/edit#heading=h.hds2i7ii7hjo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to bids.neuroimaging.io
+
+Welcome to the BIDS repository! We're excited you're here and want to contribute.  
+
+These guidelines are designed to make it as easy as possible to get involved. If you have any questions that aren't discussed below, please let us know by opening an [issue][link_issues]!
+
+Before you start you'll need to set up a free [GitHub][link_github] account and sign in. Here are some [instructions][link_signupinstructions].
+
+## Joining the community
+
+BIDS is a growing community of neuroimaging enthusiasts, and we want to make our resources accessible to and engaging for as many researchers as possible.
+We therefore require that all contributions adhere to our [Code of Conduct][link_code_of_conduct].
+
+## Where to start: labels
+
+The list of labels for current issues are [here][link_labels] and include:
+
+* [![Help Wanted](https://img.shields.io/badge/-help%20wanted-159818.svg)][link_helpwanted] *These issues contain a task that a member of the team has determined we need additional help with.*
+
+    If you feel that you can contribute to one of these issues, we especially encourage you to do so!
+
+* [![Requests](https://img.shields.io/badge/-requests-fbca04.svg)][link_requests] *These issues are asking for new features to be added to the project.*
+
+    Please try to make sure that your requested feature is distinct from any others that have already been requested or implemented. If you find one that's similar but there are subtle differences please reference the other request in your issue.
+
+## Making a change
+
+We appreciate all contributions to BIDS, but those accepted fastest will follow a workflow similar to the following:
+
+**1. Comment on an existing issue or open a new issue referencing your addition.**
+
+This allows other members of the BIDS web development team to confirm that you aren't overlapping with work that's currently underway and that everyone is on the same page with the goal of the work you're going to carry out.
+
+[This blog][link_pushpullblog] is a nice explanation of why putting this work in up front is so useful to everyone involved.
+
+**2. [Fork][link_fork] the [BIDS repository][link_bids] to your profile.**
+
+This is now your own unique copy of bids.neuroimaging.io. Changes here won't effect anyone else's work, so it's a safe space to explore edits to the code!
+
+Make sure to [keep your fork up to date][link_updateupstreamwiki] with the master repository.
+
+**3. Make the changes you've discussed.**
+
+Try to keep the changes focused. If you feel tempted to "branch out" then please make a [new branch][link_branches].
+
+**4. Submit a [pull request][link_pullrequest].**
+
+A member of the development team will review your changes to confirm that they can be merged into the main codebase.
+
+## Recognizing contributions
+
+BIDS follows the [all-contributors][link_allcontributors] specification, so we welcome and recognize all contributions from documentation to testing to code development.
+You can see a list of current contributors in our [README][link_readme].
+
+## Thank you!
+
+You're awesome. :wave::smiley:
+
+<br>
+
+*&mdash; Based on contributing guidelines from the [STEMMRoleModels][link_stemmrolemodels] project.*
+
+
+[link_github]: https://github.com/
+[link_bids]: https://github.com/INCF/BIDS
+[link_issues]: https://github.com/INCF/BIDS/issues
+[link_labels]: https://github.com/INCF/BIDS/labels
+[link_fork]: https://help.github.com/articles/fork-a-repo/
+[link_requests]: https://github.com/INCF/BIDS/labels/requests
+[link_readme]: https://github.com/INCF/BIDS/blob/gh-pages/README.md
+[link_helpwanted]: https://github.com/INCF/BIDS/labels/help%20wanted
+[link_code_of_conduct]: http://www.brainhack.org/code-of-conduct.html
+[link_stemmrolemodels]: https://github.com/KirstieJane/STEMMRoleModels
+[link_updateupstreamwiki]: https://help.github.com/articles/syncing-a-fork/
+[link_pullrequest]: https://help.github.com/articles/creating-a-pull-request/
+[link_allcontributors]: https://github.com/kentcdodds/all-contributors#emoji-key
+[link_discussingissues]: https://help.github.com/articles/discussing-projects-in-issues-and-pull-requests
+[link_pushpullblog]: https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/
+[link_branches]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
+[link_react]: https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments
+[link_signupinstructions]: https://help.github.com/articles/signing-up-for-a-new-github-account

--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@ If you'd like to contribute to the website, please see our [contributing guideli
 
 ## Contributors
 
-| [<img src="https://avatars.githubusercontent.com/chrisfilo?s=100" width="100" alt="Chris Gorgolewski" /><br /><sub>Chris Gorgolewski</sub>](http://multiplecomparisons.blogpost.com/)<br />[💻](https://github.com/INCF/BIDS/commits?author=chrisfilo) [📖](https://github.com/INCF/BIDS/commits?author=chrisfilo) | <img src="https://avatars.githubusercontent.com/dkp?s=100" width="100" alt="dkp" /><br /><sub>dkp</sub><br />[📖](https://github.com/INCF/BIDS/commits?author=dkp) | [<img src="https://avatars.githubusercontent.com/emdupre?s=100" width="100" alt="dkp" /><br /><sub>Elizabeth DuPre</sub>](http://http://emdupre.me//)<br />[📖](https://github.com/INCF/BIDS/commits?author=emdupre) |
-| :---: | :---: | :---: |
-
 This project follows the [all-contributors][link_all-contributors] specification.
+A list of all current BIDS contributors is available [here][link_bids_spec].
 
 
 [link_bids]: http://bids.neuroimaging.io
@@ -31,3 +29,4 @@ This project follows the [all-contributors][link_all-contributors] specification
 [link_get_involved]: http://bids.neuroimaging.io/#get_involved
 [link_contributing]: https://github.com/INCF/BIDS/blob/gh-pages/CONTRIBUTING.md
 [link_all-contributors]: https://github.com/kentcdodds/all-contributors#emoji-key
+[link_bids_spec]: https://docs.google.com/document/d/1HFUkAEE-pB-angVcYe6pf_-fVf4sCpOHKesUvfb8Grc/edit#heading=h.hds2i7ii7hjo

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# bids.neuroimaging.io
+
+This is the repository for the Brain Imaging Data Structure (BIDS) website, [bids.neuroimaging.io][link_bids].
+
+## About BIDS
+
+BIDS is a simple and intuitive way to organize and describe your neuroimaging and behavioral data.
+This website provides guidance on the BIDS specification, example datasets implementing BIDS standards, and existing tools for working with BIDS datasets.
+
+## About the website
+
+Built using [Bootstrap][link_bootstrap] and [Font Awesome][link_font_awesome].
+
+## Getting involved
+
+If you are interested in helping to develop BIDS standards, please [get involved][link_get_involved]!
+
+If you'd like to contribute to the website, please see our [contributing guidelines][link_contributing].
+
+## Contributors
+
+| [<img src="https://avatars.githubusercontent.com/chrisfilo?s=100" width="100" alt="Chris Gorgolewski" /><br /><sub>Chris Gorgolewski</sub>](http://multiplecomparisons.blogpost.com/)<br />[💻](https://github.com/INCF/BIDS/commits?author=chrisfilo) [📖](https://github.com/INCF/BIDS/commits?author=chrisfilo) | <img src="https://avatars.githubusercontent.com/dkp?s=100" width="100" alt="dkp" /><br /><sub>dkp</sub><br />[📖](https://github.com/INCF/BIDS/commits?author=dkp) | [<img src="https://avatars.githubusercontent.com/emdupre?s=100" width="100" alt="dkp" /><br /><sub>Elizabeth DuPre</sub>](http://http://emdupre.me//)<br />[📖](https://github.com/INCF/BIDS/commits?author=emdupre) |
+| :---: | :---: | :---: |
+
+This project follows the [all-contributors][link_all-contributors] specification.
+
+
+[link_bids]: http://bids.neuroimaging.io
+[link_bootstrap]: http://getbootstrap.com
+[link_font_awesome]: http://fontawesome.io/
+[link_get_involved]: http://bids.neuroimaging.io/#get_involved
+[link_contributing]: https://github.com/INCF/BIDS/blob/gh-pages/CONTRIBUTING.md
+[link_all-contributors]: https://github.com/kentcdodds/all-contributors#emoji-key


### PR DESCRIPTION
Initial commits for README and CONTRIBUTING files. Also incorporates the all-contributors standards. 

Currently, CONTRIBUTING points to the [brainhack code of conduct](http://www.brainhack.org/code-of-conduct.html), but this can be updated after the resolution of #9. 