### PR TITLE
ENH: Split About block into About and Benefits

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,9 @@
                         <a class="page-scroll" href="#about">About</a>
                     </li>
                     <li>
+                        <a class="page-scroll" href="#benefits">Benefits</a>
+                    </li>
+                    <li>
                         <a class="page-scroll" href="#download">The Specification</a>
                     </li>
                     <li>
@@ -88,13 +91,26 @@
     </header>
 
     <!-- About Section -->
-    <div class="text-center"><img src="bids2.png"</img></div>
     <section id="about" class="container content-section text-left">
         <div class="row">
             <div class="col-lg-12">
 
                 <h2>About BIDS</h2>
-        <p>Neuroimaging experiments result in complicated data that can be arranged in many different ways. So far there is no consensus how to organize and share data obtained in neuroimaging experiments. Even two researchers working in the same lab can opt to arrange their data in a different way. Lack of consensus (or a standard) leads to misunderstandings and time wasted on rearranging data or rewriting scripts expecting certain structure. Here we describe a simple and easy to adopt way of organizing neuroimaging and behavioral data. By using this standard you will benefit in the following ways:
+        <p>Neuroimaging experiments result in complicated data that can be arranged in many different ways. So far there is no consensus how to organize and share data obtained in neuroimaging experiments. Even two researchers working in the same lab can opt to arrange their data in a different way. Lack of consensus (or a standard) leads to misunderstandings and time wasted on rearranging data or rewriting scripts expecting certain structure. Here we describe a simple and easy to adopt way of organizing neuroimaging and behavioral data.</p>
+
+        <div class="text-center"><img src="bids2.png"</img></div>
+
+        <p>BIDS is heavily inspired by the format used internally by <a href="http://openfmri.org">OpenfMRI.org</a>. While working on BIDS we consulted many neuroscientists to make sure it covers most common experiments, but at the same time is intuitive and easy to adopt. The specification is intentionally based simple file formats and folder structures to reflect current lab practices and make it accessible to wide range of scientists coming from different backgrounds.</p>
+        <p>A good introduction to the BIDS standard can be found in the <a href="http://www.nature.com/articles/sdata201644">paper published in Nature Scientific Data</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <section id="benefits" class="container content-section text-left">
+        <div class="row">
+            <div class="col-lg-12">
+                <h2>Benefits</h2>
+        <p>By using this standard you will benefit in the following ways:
         <ul>
           <li>It will be easy for another researcher to work on your data. To understand the organization of the files and their format you will only need to refer them to this document. This is especially important if you are running your own lab and anticipate more than one person working on the same data over time. By using BIDS you will save time trying to understand and reuse data acquired by a graduate student or postdoc that has already left the lab.</li>
           <li>There is a growing number of data analysis software packages that can understand data organized according to BIDS.</li>
@@ -102,8 +118,7 @@
           <li>There are <a href="https://github.com/Squishymedia/bids-validator">validation tools</a> (also available <a href="http://incf.github.io/bids-validator/">online</a>) that can check your dataset integrity and let you easily spot missing values.</li>
           <li>We provide <a href="https://github.com/INCF/openfmri2bids">tools to convert OpenfMRI style organized data to BIDS</a></li>
         </ul></p>
-        <p>BIDS is heavily inspired by the format used internally by <a href="http://openfmri.org">OpenfMRI.org</a>. While working on BIDS we consulted many neuroscientists to make sure it covers most common experiments, but at the same time is intuitive and easy to adopt. The specification is intentionally based simple file formats and folder structures to reflect current lab practices and make it accessible to wide range of scientists coming from different backgrounds.</p>
-        <p>Software currently supporting BIDS:</p>
+        <p id="software">Software currently supporting BIDS:</p>
         <ul>
          <li><a href="http://bids-apps.neuroimaging.io">BIDS Apps</a> (a growing set of portable containerized data processing pipelines that understand BIDS datasets)</li>
          <li>Converters</li>
@@ -144,7 +159,7 @@
           <li><a href="http://preprocessed-connectomes-project.org/quality-assessment-protocol/">QAP</a> </li>
          </ul>
         <br>
-        <p>A good introduction to the BIDS standard can be found in the <a href="http://www.nature.com/articles/sdata201644">paper published in Nature Scientific Data</a>.<br>
+        <p>
         A description of how to build containerized apps supporting BIDS inputs can be found in the <a href="http://doi.org/10.1371/journal.pcbi.1005209">paper published in PLOS Computational Biology</a>.</p>
 
             </div>

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
         <p>By using this standard you will benefit in the following ways:
         <ul>
           <li>It will be easy for another researcher to work on your data. To understand the organization of the files and their format you will only need to refer them to this document. This is especially important if you are running your own lab and anticipate more than one person working on the same data over time. By using BIDS you will save time trying to understand and reuse data acquired by a graduate student or postdoc that has already left the lab.</li>
-          <li>There is a growing number of data analysis software packages that can understand data organized according to BIDS.</li>
+          <li>There is a growing number of <a href="#software">data analysis software packages</a> that can understand data organized according to BIDS.</li>
           <li>Databases such as <a href="http://openfmri.org">OpenfMRI.org</a>, <a href="http://www.loris.ca">LORIS</a>, <a href="https://portal.mrn.org">COINS</a>, <a href="https://central.xnat.org/">XNAT</a>, <a href="https://scitran.github.io/">SciTran</a> and others will accept and export datasets organized according to BIDS. If you ever plan to share your data publicly (nowadays some journals require this) you can speed up the curation process by using BIDS.</li>
           <li>There are <a href="https://github.com/Squishymedia/bids-validator">validation tools</a> (also available <a href="http://incf.github.io/bids-validator/">online</a>) that can check your dataset integrity and let you easily spot missing values.</li>
           <li>We provide <a href="https://github.com/INCF/openfmri2bids">tools to convert OpenfMRI style organized data to BIDS</a></li>


### PR DESCRIPTION
I find current about a bit too non-specific, so shuffled pieces around to provide first the About (blurb) and then list of benefits also adding id= for software paragraph so a dedicated url could be used where needed to point to software pieces.

Also, I would have increased size for the `ul.li` items but didn't want to disturb it all in one shot ;)  Ideally also if someone could word benefits more concisely with `<strong>`ifying main benefits keywords in that rewording -- could be easier to digest and deliver the main points.